### PR TITLE
Remove virus link from README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 = gvm-gui
 
 
-A Griffon GUI for GVM http://gvmtool.net
+A Griffon GUI for GVM
 
 = Setup IDE
 griffon integrate-with --idea


### PR DESCRIPTION
Link "http://gvmtool.net" redirects to ads site